### PR TITLE
Delete created test files in `afterEach` instead of in `afterAll`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,8 @@ jobs:
         with:
           fetch-depth: 0
       - name: Lint commit messages
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         uses: wagoid/commitlint-github-action@v1
       - uses: actions/setup-node@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   ci:
-    if: github.event_name == 'push' && contains(toJson(github.event.commits), '***NO_CI***') == false && contains(toJson(github.event.commits), '[ci skip]') == false && contains(toJson(github.event.commits), '[skip ci]') == false
+    if: "!contains(github.event.head_commit.message , '[skip-ci]')"
     name: CI Flow
     runs-on: ubuntu-latest
     strategy:

--- a/tests/unit/helpers.spec.ts
+++ b/tests/unit/helpers.spec.ts
@@ -17,6 +17,20 @@ import fs from 'fs';
 import path from 'path';
 
 describe('helpers', () => {
+  const absoluteDistFolderPath = path.resolve(__dirname, 'dist');
+  let createdFiles: string[] = [];
+  let createdDirectories: string[] = [];
+
+  beforeAll(() => fs.mkdirSync(absoluteDistFolderPath));
+
+  afterEach(() => {
+    deleteCreatedFilesAndDirectories(createdFiles, createdDirectories);
+    createdFiles = [];
+    createdDirectories = [];
+  });
+
+  afterAll(() => fs.rmdirSync(absoluteDistFolderPath));
+
   // This function does not check if the directory path to be added exists and
   // is in fact a directory, so a file path, or a non existent directory path
   // could be added
@@ -55,13 +69,6 @@ describe('helpers', () => {
   });
 
   describe('createMockFile', () => {
-    const createdFiles: string[] = [];
-    const createdDirectories: string[] = [];
-
-    afterAll(() =>
-      deleteCreatedFilesAndDirectories(createdFiles, createdDirectories)
-    );
-
     it('should create an empty file', () => {
       const filePath = './dist/empty-file.json';
       const absoluteFilePath = path.resolve(__dirname, filePath);

--- a/tests/unit/helpers.spec.ts
+++ b/tests/unit/helpers.spec.ts
@@ -5,6 +5,8 @@
  * @packageDocumentation
  */
 
+/* eslint-disable sonarjs/no-duplicate-string */
+
 import {
   addDirectoryToDeleteQueue,
   createMockFile,

--- a/tests/unit/helpers.spec.ts
+++ b/tests/unit/helpers.spec.ts
@@ -37,7 +37,6 @@ describe('helpers', () => {
   describe('addDirectoryToDeleteQueue', () => {
     it('should add directory to delete queue', () => {
       const deleteQueue: string[] = [];
-      // eslint-disable-next-line sonarjs/no-duplicate-string
       const directoryPath = '/home/sebastian/';
       const expectedDeleteQueue = [directoryPath];
 
@@ -70,58 +69,48 @@ describe('helpers', () => {
 
   describe('createMockFile', () => {
     it('should create an empty file', () => {
-      const filePath = './dist/empty-file.json';
-      const absoluteFilePath = path.resolve(__dirname, filePath);
+      const emptyFilePath = `${absoluteDistFolderPath}/empty-file.json`;
       const fileContent = '';
 
-      createMockFile(absoluteFilePath, fileContent);
-      createdFiles.push(absoluteFilePath);
-      const createdFileContent: Buffer = fs.readFileSync(absoluteFilePath);
+      createMockFile(emptyFilePath, fileContent);
+      createdFiles.push(emptyFilePath);
+      const createdFileContent: Buffer = fs.readFileSync(emptyFilePath);
       const stringifiedCreatedFileContent = String(createdFileContent);
 
       expect(stringifiedCreatedFileContent).toBe(fileContent);
     });
 
     it('should create a file with some content', () => {
-      const filePath = './dist/non-empty-file.txt';
-      const absoluteFilePath = path.resolve(__dirname, filePath);
+      const nonEmptyFilePath = `${absoluteDistFolderPath}/non-empty-file.txt`;
       const fileContent = 'I am not empty';
 
-      createMockFile(absoluteFilePath, fileContent);
-      createdFiles.push(absoluteFilePath);
-      const createdFileContent: Buffer = fs.readFileSync(absoluteFilePath);
+      createMockFile(nonEmptyFilePath, fileContent);
+      createdFiles.push(nonEmptyFilePath);
+      const createdFileContent: Buffer = fs.readFileSync(nonEmptyFilePath);
       const stringifiedCreatedFileContent = String(createdFileContent);
 
       expect(stringifiedCreatedFileContent).toBe(fileContent);
     });
 
     it('should create a file in a non existent directory', () => {
-      const filePath = './dist/new-folder/new-file.txt';
-      const absoluteFilePath = path.resolve(__dirname, filePath);
+      const emptyFilePath = `${absoluteDistFolderPath}/new-folder/new-file.txt`;
       const fileContent = '';
 
-      const absoluteDirectoryPath = createMockFile(
-        absoluteFilePath,
-        fileContent
-      );
-      createdFiles.push(absoluteFilePath);
+      const absoluteDirectoryPath = createMockFile(emptyFilePath, fileContent);
+      createdFiles.push(emptyFilePath);
       addDirectoryToDeleteQueue(createdDirectories, absoluteDirectoryPath);
-      const read = (): Buffer => fs.readFileSync(absoluteFilePath);
+      const read = (): Buffer => fs.readFileSync(emptyFilePath);
 
       expect(read).not.toThrow();
     });
 
     it('should return the directory name of the created file', () => {
-      const filePath = './dist/file.txt';
-      const absoluteFilePath = path.resolve(__dirname, filePath);
+      const emptyFilePath = `${absoluteDistFolderPath}/file.txt`;
       const fileContent = '';
 
-      const absoluteDirectoryPath = createMockFile(
-        absoluteFilePath,
-        fileContent
-      );
-      createdFiles.push(absoluteFilePath);
-      const expectedAbsoluteDirectoryPath = path.dirname(absoluteFilePath);
+      const absoluteDirectoryPath = createMockFile(emptyFilePath, fileContent);
+      createdFiles.push(emptyFilePath);
+      const expectedAbsoluteDirectoryPath = path.dirname(emptyFilePath);
 
       expect(absoluteDirectoryPath).toBe(expectedAbsoluteDirectoryPath);
     });
@@ -133,12 +122,11 @@ describe('helpers', () => {
     it('should delete the specified files and directories', () => {
       const createdFiles: string[] = [];
       const createdDirectories: string[] = [];
-      const filePaths = [
-        './dist/new-folder/new-file.txt',
-        './dist/new-folder-2/new-file-2.txt',
+      const absoluteFilePaths = [
+        `${absoluteDistFolderPath}/new-folder/new-file.txt`,
+        `${absoluteDistFolderPath}/new-folder-2/new-file-2.txt`,
       ];
-      filePaths.forEach((filePath) => {
-        const absoluteFilePath = path.resolve(__dirname, filePath);
+      absoluteFilePaths.forEach((absoluteFilePath: string) => {
         const absoluteDirectoryPath = createMockFile(absoluteFilePath, '');
         createdFiles.push(absoluteFilePath);
         addDirectoryToDeleteQueue(createdDirectories, absoluteDirectoryPath);

--- a/tests/unit/index.spec.ts
+++ b/tests/unit/index.spec.ts
@@ -11,9 +11,24 @@ import {
   addDirectoryToDeleteQueue,
 } from '../helpers';
 
+import fs from 'fs';
 import path from 'path';
 
 describe('JSON File Handler', () => {
+  const absoluteDistFolderPath = path.resolve(__dirname, 'dist');
+  let createdFiles: string[] = [];
+  let createdDirectories: string[] = [];
+
+  beforeAll(() => fs.mkdirSync(absoluteDistFolderPath));
+
+  afterEach(() => {
+    deleteCreatedFilesAndDirectories(createdFiles, createdDirectories);
+    createdFiles = [];
+    createdDirectories = [];
+  });
+
+  afterAll(() => fs.rmdirSync(absoluteDistFolderPath));
+
   describe('read', () => {
     it('should read a valid JSON file', async () => {
       const validJsonPath = path.resolve(__dirname, './mocks/valid.json');
@@ -79,13 +94,6 @@ describe('JSON File Handler', () => {
   });
 
   describe('join', () => {
-    const createdFiles: string[] = [];
-    const createdDirectories: string[] = [];
-
-    afterAll(() =>
-      deleteCreatedFilesAndDirectories(createdFiles, createdDirectories)
-    );
-
     it('should create a new file', async () => {
       const nonExistentFilePath = path.resolve(
         __dirname,
@@ -255,13 +263,6 @@ describe('JSON File Handler', () => {
   });
 
   describe('overwrite', () => {
-    const createdFiles: string[] = [];
-    const createdDirectories: string[] = [];
-
-    afterAll(() =>
-      deleteCreatedFilesAndDirectories(createdFiles, createdDirectories)
-    );
-
     it('should create a new file', async () => {
       const nonExistentFilePath = path.resolve(
         __dirname,

--- a/tests/unit/index.spec.ts
+++ b/tests/unit/index.spec.ts
@@ -31,32 +31,32 @@ describe('JSON File Handler', () => {
 
   describe('read', () => {
     it('should read a valid JSON file', async () => {
-      const validJsonPath = path.resolve(__dirname, './mocks/valid.json');
+      const jsonFilePath = path.resolve(__dirname, './mocks/valid.json');
 
-      const readPromise = read(validJsonPath);
+      const readPromise = read(jsonFilePath);
 
       await expectAsync(readPromise).toBeResolved();
     });
 
     it('should return the content of a JSON file', async () => {
-      const validJsonPath = path.resolve(__dirname, './mocks/valid.json');
+      const jsonFilePath = path.resolve(__dirname, './mocks/valid.json');
       const expectedJsonContent = {
         resX: 1920,
         resY: 1080,
       };
 
-      const jsonContent = await read(validJsonPath);
+      const jsonContent = await read(jsonFilePath);
 
       expect(jsonContent).toEqual(expectedJsonContent);
     });
 
     it('should read a valid JSON file without .json extension', async () => {
-      const validJsonPath = path.resolve(
+      const jsonFilePath = path.resolve(
         __dirname,
         './mocks/valid.json-not-json'
       );
 
-      const readPromise = read(validJsonPath);
+      const readPromise = read(jsonFilePath);
 
       await expectAsync(readPromise).toBeResolved();
     });
@@ -73,9 +73,12 @@ describe('JSON File Handler', () => {
     });
 
     it('should throw an error if the file is not a valid JSON file', async () => {
-      const invalidJsonPath = path.resolve(__dirname, './mocks/invalid.json');
+      const invalidJsonFilePath = path.resolve(
+        __dirname,
+        './mocks/invalid.json'
+      );
 
-      const readPromise = read(invalidJsonPath);
+      const readPromise = read(invalidJsonFilePath);
 
       await expectAsync(readPromise).toBeRejectedWithError(
         JSONFileHandlerErrorMessage.NOT_A_JSON
@@ -95,10 +98,7 @@ describe('JSON File Handler', () => {
 
   describe('join', () => {
     it('should create a new file', async () => {
-      const nonExistentFilePath = path.resolve(
-        __dirname,
-        './dist/new-file.json'
-      );
+      const nonExistentFilePath = `${absoluteDistFolderPath}/new-file.json`;
       const jsonContent = {
         name: 'John Doe',
         age: 33,
@@ -111,10 +111,7 @@ describe('JSON File Handler', () => {
     });
 
     it('should create a new file in a new directory', async () => {
-      const nonExistentFilePath = path.resolve(
-        __dirname,
-        './dist/new-folder/new-file.json'
-      );
+      const nonExistentFilePath = `${absoluteDistFolderPath}/new-folder/new-file.json`;
       const jsonContent = {
         name: 'John Doe',
         age: 33,
@@ -131,7 +128,7 @@ describe('JSON File Handler', () => {
     });
 
     it('should merge an object with the content of an existing file', async () => {
-      const nonExistentFilePath = path.resolve(__dirname, './dist/join.json');
+      const jsonFilePath = `${absoluteDistFolderPath}/join.json`;
       const jsonContent = {
         object: {
           a: 12,
@@ -143,8 +140,8 @@ describe('JSON File Handler', () => {
         },
         array: ['one', 'two'],
       };
-      await join(nonExistentFilePath, jsonContent);
-      createdFiles.push(nonExistentFilePath);
+      await join(jsonFilePath, jsonContent);
+      createdFiles.push(jsonFilePath);
       const contentToJoin = {
         object: {
           b: {
@@ -171,46 +168,40 @@ describe('JSON File Handler', () => {
         array: ['one', 'two', 'three', 'four'],
       };
 
-      await join(nonExistentFilePath, contentToJoin);
-      const fileContent = await read(nonExistentFilePath);
+      await join(jsonFilePath, contentToJoin);
+      const fileContent = await read(jsonFilePath);
 
       expect(fileContent).toEqual(expectedJsonContent);
     });
 
     it('should overwrite the content of an existing empty file', async () => {
-      const newEmptyFilePath = path.resolve(
-        __dirname,
-        './dist/join-empty.json'
-      );
-      createMockFile(newEmptyFilePath, '');
-      createdFiles.push(newEmptyFilePath);
+      const emptyFilePath = `${absoluteDistFolderPath}/join-empty.json`;
+      createMockFile(emptyFilePath, '');
+      createdFiles.push(emptyFilePath);
       const newJsonContent = {
         name: 'Jane Doe',
         age: 31,
         height: 170,
       };
 
-      await join(newEmptyFilePath, newJsonContent);
-      const fileContent = await read(newEmptyFilePath);
+      await join(emptyFilePath, newJsonContent);
+      const fileContent = await read(emptyFilePath);
 
       expect(fileContent).toEqual(newJsonContent);
     });
 
     it('should fail to merge the content of an existing invalid JSON file', async () => {
-      const newInvalidJsonFilePath = path.resolve(
-        __dirname,
-        './dist/join-invalid.json'
-      );
+      const invalidJsonFilePath = `${absoluteDistFolderPath}/join-invalid.json`;
       const invalidJsonContent = 'i am not a valid JSON content';
-      createMockFile(newInvalidJsonFilePath, invalidJsonContent);
-      createdFiles.push(newInvalidJsonFilePath);
+      createMockFile(invalidJsonFilePath, invalidJsonContent);
+      createdFiles.push(invalidJsonFilePath);
       const newJsonContent = {
         name: 'Jane Doe',
         age: 31,
         height: 170,
       };
 
-      const joinPromise = join(newInvalidJsonFilePath, newJsonContent);
+      const joinPromise = join(invalidJsonFilePath, newJsonContent);
 
       await expectAsync(joinPromise).toBeRejectedWithError(
         JSONFileHandlerErrorMessage.NOT_A_JSON
@@ -220,10 +211,7 @@ describe('JSON File Handler', () => {
     // No further testing is done in this field as `isAnObject` util takes care
     // of this and it's already well tested
     it('should fail with an invalid object', async () => {
-      const nonExistentFilePath = path.resolve(
-        __dirname,
-        './dist/join-fail.json'
-      );
+      const nonExistentFilePath = `${absoluteDistFolderPath}/join-fail.json`;
       const jsonContent = ['black', 'red', 'blue', 'orange'];
 
       const writePromise = join(nonExistentFilePath, jsonContent);
@@ -234,10 +222,7 @@ describe('JSON File Handler', () => {
     });
 
     it('should fail to merge the content of an object with the content of a read only file', async () => {
-      const newReadOnlyFilePath = path.resolve(
-        __dirname,
-        './dist/join-read-only.json'
-      );
+      const readOnlyFilePath = `${absoluteDistFolderPath}/join-read-only.json`;
       const jsonContent = {
         name: 'Jane Doe',
         age: 31,
@@ -245,18 +230,18 @@ describe('JSON File Handler', () => {
       };
       const stringifiedJsonContent = JSON.stringify(jsonContent);
       createMockFile(
-        newReadOnlyFilePath,
+        readOnlyFilePath,
         stringifiedJsonContent,
         FilePermission.readOnly
       );
-      createdFiles.push(newReadOnlyFilePath);
+      createdFiles.push(readOnlyFilePath);
       const newJsonContent = {
         name: 'Jane Doe',
         age: 31,
         height: 170,
       };
 
-      const joinPromise = join(newReadOnlyFilePath, newJsonContent);
+      const joinPromise = join(readOnlyFilePath, newJsonContent);
 
       await expectAsync(joinPromise).toBeRejected();
     });
@@ -264,10 +249,7 @@ describe('JSON File Handler', () => {
 
   describe('overwrite', () => {
     it('should create a new file', async () => {
-      const nonExistentFilePath = path.resolve(
-        __dirname,
-        './dist/new-file.json'
-      );
+      const nonExistentFilePath = `${absoluteDistFolderPath}/new-file.json`;
       const jsonContent = {
         name: 'John Doe',
         age: 33,
@@ -280,10 +262,7 @@ describe('JSON File Handler', () => {
     });
 
     it('should create a new file in a new directory', async () => {
-      const nonExistentFilePath = path.resolve(
-        __dirname,
-        './dist/new-folder/new-file.json'
-      );
+      const nonExistentFilePath = `${absoluteDistFolderPath}/new-folder/new-file.json`;
       const jsonContent = {
         name: 'John Doe',
         age: 33,
@@ -300,72 +279,60 @@ describe('JSON File Handler', () => {
     });
 
     it('should overwrite the content of an existing file', async () => {
-      const nonExistentFilePath = path.resolve(
-        __dirname,
-        './dist/overwrite.json'
-      );
+      const jsonFilePath = `${absoluteDistFolderPath}/overwrite.json`;
       const jsonContent = {
         name: 'John Doe',
         age: 33,
       };
-      await overwrite(nonExistentFilePath, jsonContent);
-      createdFiles.push(nonExistentFilePath);
+      await overwrite(jsonFilePath, jsonContent);
+      createdFiles.push(jsonFilePath);
       const newJsonContent = {
         name: 'Jane Doe',
         age: 31,
         height: 170,
       };
 
-      await overwrite(nonExistentFilePath, newJsonContent);
-      const fileContent = await read(nonExistentFilePath);
+      await overwrite(jsonFilePath, newJsonContent);
+      const fileContent = await read(jsonFilePath);
 
       expect(fileContent).toEqual(newJsonContent);
     });
 
     it('should overwrite the content of an existing empty file', async () => {
-      const newEmptyFilePath = path.resolve(
-        __dirname,
-        './dist/join-empty.json'
-      );
-      createMockFile(newEmptyFilePath, '');
-      createdFiles.push(newEmptyFilePath);
+      const emptyFilePath = `${absoluteDistFolderPath}/overwrite-empty.json`;
+      createMockFile(emptyFilePath, '');
+      createdFiles.push(emptyFilePath);
       const newJsonContent = {
         name: 'Jane Doe',
         age: 31,
         height: 170,
       };
 
-      await overwrite(newEmptyFilePath, newJsonContent);
-      const fileContent = await read(newEmptyFilePath);
+      await overwrite(emptyFilePath, newJsonContent);
+      const fileContent = await read(emptyFilePath);
 
       expect(fileContent).toEqual(newJsonContent);
     });
 
     it('should overwrite the content of an existing invalid JSON file', async () => {
-      const newInvalidJsonFilePath = path.resolve(
-        __dirname,
-        './dist/join-invalid.json'
-      );
+      const invalidJsonFilePath = `${absoluteDistFolderPath}/overwrite-invalid.json`;
       const invalidJsonContent = 'i am not a valid JSON content';
-      createMockFile(newInvalidJsonFilePath, invalidJsonContent);
-      createdFiles.push(newInvalidJsonFilePath);
+      createMockFile(invalidJsonFilePath, invalidJsonContent);
+      createdFiles.push(invalidJsonFilePath);
       const newJsonContent = {
         name: 'Jane Doe',
         age: 31,
         height: 170,
       };
 
-      await overwrite(newInvalidJsonFilePath, newJsonContent);
-      const fileContent = await read(newInvalidJsonFilePath);
+      await overwrite(invalidJsonFilePath, newJsonContent);
+      const fileContent = await read(invalidJsonFilePath);
 
       expect(fileContent).toEqual(newJsonContent);
     });
 
     it('should fail with an invalid object', async () => {
-      const nonExistentFilePath = path.resolve(
-        __dirname,
-        './dist/overwrite-fail.json'
-      );
+      const nonExistentFilePath = `${absoluteDistFolderPath}/overwrite-fail.json`;
       const jsonContent = ['black', 'red', 'blue', 'orange'];
 
       const writePromise = overwrite(nonExistentFilePath, jsonContent);
@@ -376,10 +343,7 @@ describe('JSON File Handler', () => {
     });
 
     it('should fail overwrite the content of a read only file', async () => {
-      const newReadOnlyFilePath = path.resolve(
-        __dirname,
-        './dist/join-read-only.json'
-      );
+      const readOnlyFilePath = `${absoluteDistFolderPath}/overwrite-read-only.json`;
       const jsonContent = {
         name: 'Jane Doe',
         age: 31,
@@ -387,18 +351,18 @@ describe('JSON File Handler', () => {
       };
       const stringifiedJsonContent = JSON.stringify(jsonContent);
       createMockFile(
-        newReadOnlyFilePath,
+        readOnlyFilePath,
         stringifiedJsonContent,
         FilePermission.readOnly
       );
-      createdFiles.push(newReadOnlyFilePath);
+      createdFiles.push(readOnlyFilePath);
       const newJsonContent = {
         name: 'Jane Doe',
         age: 31,
         height: 170,
       };
 
-      const overwritePromise = overwrite(newReadOnlyFilePath, newJsonContent);
+      const overwritePromise = overwrite(readOnlyFilePath, newJsonContent);
 
       await expectAsync(overwritePromise).toBeRejected();
     });

--- a/tests/unit/index.spec.ts
+++ b/tests/unit/index.spec.ts
@@ -1,3 +1,5 @@
+/* eslint-disable sonarjs/no-duplicate-string */
+
 import { read, join, overwrite } from '../../src/index';
 import {
   JSONFileHandlerErrorMessage,

--- a/tests/unit/utils.spec.ts
+++ b/tests/unit/utils.spec.ts
@@ -1,3 +1,5 @@
+/* eslint-disable sonarjs/no-duplicate-string */
+
 import { isAnObject, isAValidJsonString } from '../../src/utils';
 
 describe('JSON Handler Utils', () => {


### PR DESCRIPTION
# Type of Change

Unit tests

# Description

This PR fixes the next two issues :
- `dist` folder, where the files and folders are created as part  of the test process, is part of the repository, rather than being created and deleted as part of the test process. Now `dist` folder is created in `beforeAll` and deleted in `afterAll` in each test file
- Created files and folders are deleted after a suit finishes the execution of its tests, rather than deleting them after the execution of each test. With the current approach two different test cases of the same suit can't create a file with the same name, because in the second test to run it will be already created, changing the expected behavior. Now the created files and folders are deleted in `afterEach` instead of in `afterAll`

Aside from that, some variable containing file paths have been renamed and `sonarjs/no-duplicate-string` rule was disabled in all test files.